### PR TITLE
Fix XXE in XML body handling

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -31,6 +31,9 @@ class Request
      * @param array<string,mixed>|null $post
      * @param array<string,mixed>|null $cookies
      * @param array<string,mixed>|null $files
+     *
+     * XML payloads are parsed with `LIBXML_NONET` to prevent external entity
+     * loading.
      */
     public static function create(
         ?array $server = null,
@@ -98,7 +101,7 @@ class Request
 
         $parsedBody = match ($contentType) {
             "application/json" => json_decode($rawInput, true) ?? [],
-            "application/xml", "text/xml" => ($xml = simplexml_load_string($rawInput))
+            "application/xml", "text/xml" => ($xml = simplexml_load_string($rawInput, null, LIBXML_NONET))
                 ? json_decode(json_encode($xml, JSON_THROW_ON_ERROR), true)
                 : [],
             default => $post,

--- a/tests/Unit/RequestFactoryTest.php
+++ b/tests/Unit/RequestFactoryTest.php
@@ -81,3 +81,20 @@ it("normalizes files array into flat structure", function () {
     expect($req->files[0]["name"])->toBe("file.txt");
     expect($req->files[0]["error"])->toBe(UPLOAD_ERR_OK);
 });
+
+it("ignores external entities in XML payloads", function () {
+    $server = fakeServer([
+        "REQUEST_METHOD" => "POST",
+        "REQUEST_URI" => "/xml",
+    ]);
+    $headers = ["Content-Type" => "application/xml"];
+    $body = <<<'XML'
+<?xml version="1.0"?>
+<!DOCTYPE data [<!ENTITY ext SYSTEM "file:///etc/passwd">]>
+<root><a>&ext;</a></root>
+XML;
+
+    $req = Request::create($server, $headers, [], [], [], [], $body);
+
+    expect($req->input('a'))->not()->toBeString();
+});


### PR DESCRIPTION
## Summary
- harden Request factory against XXE by passing `LIBXML_NONET`
- test malicious XML input

## Testing
- `composer install --no-interaction`
- `./vendor/bin/pest`


------
https://chatgpt.com/codex/tasks/task_e_68864f12364c832191585a822ccb3b0e