### PR TITLE
Add strict types to src only

### DIFF
--- a/src/Api/Jwt.php
+++ b/src/Api/Jwt.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Essentio\Api;
 

--- a/src/Api/functions.php
+++ b/src/Api/functions.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Essentio\Api\Jwt;
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Essentio;
 

--- a/src/Cli/Argument.php
+++ b/src/Cli/Argument.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Essentio\Cli;
 

--- a/src/Cli/functions.php
+++ b/src/Cli/functions.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Essentio\Cli\Argument;
 

--- a/src/Container.php
+++ b/src/Container.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Essentio;
 

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Essentio;
 

--- a/src/Extra/HttpClient.php
+++ b/src/Extra/HttpClient.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Essentio\Extra;
 

--- a/src/Extra/Query.php
+++ b/src/Extra/Query.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Essentio\Extra;
 

--- a/src/Extra/functions.php
+++ b/src/Extra/functions.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Essentio\Extra\HttpClient;
 use Essentio\Extra\Query;

--- a/src/FrameworkException.php
+++ b/src/FrameworkException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Essentio;
 

--- a/src/Http/Extra/Cast.php
+++ b/src/Http/Extra/Cast.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Essentio\Http\Extra;
 

--- a/src/Http/Extra/Validate.php
+++ b/src/Http/Extra/Validate.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Essentio\Http\Extra;
 

--- a/src/Http/HttpException.php
+++ b/src/Http/HttpException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Essentio\Http;
 

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Essentio\Http;
 

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Essentio\Http;
 

--- a/src/Http/Route.php
+++ b/src/Http/Route.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Essentio\Http;
 

--- a/src/Http/Router.php
+++ b/src/Http/Router.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Essentio\Http;
 

--- a/src/Http/ValidationException.php
+++ b/src/Http/ValidationException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Essentio\Http;
 

--- a/src/Http/functions.php
+++ b/src/Http/functions.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Essentio\Http\Request;
 use Essentio\Http\Response;

--- a/src/Web/Session.php
+++ b/src/Web/Session.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Essentio\Web;
 

--- a/src/Web/Template.php
+++ b/src/Web/Template.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Essentio\Web;
 

--- a/src/Web/functions.php
+++ b/src/Web/functions.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Essentio\Web\Session;
 use Essentio\Web\Template;

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Essentio\Container;
 use Essentio\Application;


### PR DESCRIPTION
## Summary
- insert strict type declarations in framework code under `src/`
- revert strict type declarations from scripts in `bin/`
- run formatting and static analysis

## Testing
- `composer analyze`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68864efff9448321b9b94cadbf64f4a1